### PR TITLE
Modify insertCommand functionality

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -2,7 +2,7 @@
     "name": "SLext",
     "short_name": "SLext",
     "description": "SLext enhances your editing experience on ShareLatex by providing tabs, themes and more to the ShareLatex website.",
-    "version": "1.0.3",
+    "version": "1.1.0",
     "manifest_version": 2,
     "icons": {
         "16": "images/icon-16.png",

--- a/app/scripts/editorcommands.ts
+++ b/app/scripts/editorcommands.ts
@@ -23,15 +23,24 @@ export class EditorCommands {
 
     public wrapSelectedText() {
         let command = prompt("Wrapping command");
-        if (command == null) return;
+        command = command.replace(/ /g, ''); //remove all spaces
+        if (command == null || command.length == 0) return;
         let injectedFunction = function (command) {
             var editor = _debug_editors[0];
             var range = editor.getSelectionRange();
             var start = range.start,
                 end = range.end;
+               
             editor.getSession().insert(end, "}");
             editor.getSession().insert(start, (command ? "\\" : "") + command + "{");
             editor.clearSelection();
+
+            if(start.row == end.row && start.column == end.column) { //no text selected
+            	editor.gotoLine(start.row + 1, start.column + 2 + command.length); //2 for \{
+            } else {
+            	editor.gotoLine(end.row + 1, end.column + 3 + command.length); //3 for \{}
+            }
+
         }
         PageHook.call(injectedFunction, [command]);
     }

--- a/app/scripts/editorcommands.ts
+++ b/app/scripts/editorcommands.ts
@@ -24,7 +24,7 @@ export class EditorCommands {
     public wrapSelectedText() {
         let command = prompt("Wrapping command");
         command = command.replace(/ /g, ''); //remove all spaces
-        if (command == null || command.length == 0) return;
+        if (command == null) return;
         let injectedFunction = function (command) {
             var editor = _debug_editors[0];
             var range = editor.getSelectionRange();
@@ -38,7 +38,11 @@ export class EditorCommands {
             if(start.row == end.row && start.column == end.column) { //no text selected
             	editor.gotoLine(start.row + 1, start.column + 2 + command.length); //2 for \{
             } else {
-            	editor.gotoLine(end.row + 1, end.column + 3 + command.length); //3 for \{}
+              if(command.length > 0) {
+                	editor.gotoLine(end.row + 1, end.column + 3 + command.length); //3 for \{}
+              } else {
+                	editor.gotoLine(end.row + 1, end.column + 2); //2 for {}
+              }
             }
 
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slext",
   "private": true,
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Enhances the ShareLatex experience",
   "scripts": {
     "start": "npm run dev:chrome",


### PR DESCRIPTION
When pressing ALT + C, a window will pop up to insert a command.

I've added/corrected the following functionality:

- When inserting an empty command, it will exit (do nothing)
- When inserting a command with spaces, it will remove the spaces first
  - If the command only contains spaces, it will be empty after the removal and then simply exit
- When inserting a command around text, the cursor will be placed behind the closing '}'
- When inserting a command without selected text, the cursor will be placed between the '{' and '}', ready to enter text.