### PR TITLE
Added Firefox Add-ons link to extension in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ Then in Chrome, go to [chrome://extensions](chrome://extensions)
 Drag the packed chrome extension from the 'packages' folder onto the page to install the extension.
 
 ### Firefox
-Clone repository
+
+Download from [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/slext/) or install from source.
+
+To install from source, clone the repository:
+
 ```bash
 git clone git@github.com:hrjakobsen/slext.git
 cd slext


### PR DESCRIPTION
When trying out this plugin for Firefox, I ran into errors installing gulp for compiling from source and resorted to finding a compiled entry to the Firefox Add-ons-browser. This entry was not listed in the README.md and it seems up to date `v1.3.1`. 