### PR TITLE
Fix typescript error

### DIFF
--- a/app/scripts/tabs.ts
+++ b/app/scripts/tabs.ts
@@ -139,7 +139,7 @@ export class TabModule {
             }
 
             if (self._tabs.includes(clickedTab)) {
-                $(clickedTab.file.handle)[0].click();
+                ($(clickedTab.file.handle)[0] as HTMLElement).click();
             }
         });
 


### PR DESCRIPTION
Typescript gave me the error `Property 'click' does not exist on type 'Element'`.
Casting the element to an HTMLElement fixed this.