### PR TITLE
Shortcuts for jumping to previous tab and changing layout 

### DIFF
--- a/app/scripts/commandpalette/commandpalette.ts
+++ b/app/scripts/commandpalette/commandpalette.ts
@@ -147,9 +147,11 @@ export class CommandPalette {
             const f = items[i];
             const match = $(Utils.format(CommandPalette.result, f));
             match.click((_e) => {
-                this.select(i);
                 this.close();
                 backend.selected(f);
+            });
+            match.hover((_e) => {
+                this.select(i);
             });
             match.data("t", f);
             match.data("b", backend);

--- a/app/scripts/editorcommands.ts
+++ b/app/scripts/editorcommands.ts
@@ -21,6 +21,16 @@ export class EditorCommands {
             this.jumpToFile();
             e.preventDefault();
         });
+
+        this.shortcut.addEventListener("Meta+Y", (e) => {
+            slext.toggleFullScreenPDFEditor();
+            e.preventDefault();
+        });
+
+        this.shortcut.addEventListener("Meta+U", (e) => {
+            slext.goToSplitScreen();
+            e.preventDefault();
+        });
     }
 
     public wrapSelectedText(): void {

--- a/app/scripts/slext.ts
+++ b/app/scripts/slext.ts
@@ -40,15 +40,59 @@ export class Slext extends Dispatcher {
         return $(".full-size.ng-scope:not(.ng-hide)[ng-show=\"ui.view == 'pdf'\"]").length > 0;
     }
 
+    public isFullScreenEditor(): boolean {
+        return !this.isFullScreenPDF() && !this.isSplitScreen();
+    }
+
     public isHistoryOpen(): boolean {
         return $("#ide-body.ide-history-open").length > 0;
     }
 
-    public goToFullScreenPDF(): void {
+    private _toggleFullScreenPDFEditor(): void {
         const button = $('[ng-click="togglePdfView()"]');
         if (button.length) {
             (button[0] as HTMLElement).click();
         }
+    }
+
+    public toggleFullScreenPDFEditor(): void {
+        if (this.isSplitScreen()) this.goToFullScreenPDF();
+        else this._toggleFullScreenPDFEditor();
+    }
+
+    public goToFullScreenEditor(): void {
+        if (this.isSplitScreen()) {
+            const button = $("[ng-click=\"switchToFlatLayout('pdf')\"]");
+            if (button.length) {
+                (button[0] as HTMLElement).click();
+            }
+        } else if (!this.isFullScreenEditor()) {
+            this.toggleFullScreenPDFEditor();
+        }
+    }
+
+    public goToFullScreenPDF(): void {
+        if (this.isSplitScreen()) {
+            const button = $("[ng-click=\"switchToFlatLayout('pdf')\"]");
+            if (button.length) {
+                (button[0] as HTMLElement).click();
+            }
+        } else if (!this.isFullScreenPDF()) {
+            this._toggleFullScreenPDFEditor();
+        }
+    }
+
+    public goToSplitScreen(): void {
+        if (!this.isSplitScreen()) {
+            const button = $("[ng-click=\"switchToSideBySideLayout('editor')\"]");
+            if (button.length) {
+                (button[0] as HTMLElement).click();
+            }
+        }
+    }
+
+    public isSplitScreen(): boolean {
+        return $('.ng-hide[ng-click="togglePdfView()"]').length > 0;
     }
 
     private loadingFinished(): void {
@@ -78,9 +122,15 @@ export class Slext extends Dispatcher {
             this.dispatch("editorChanged");
         });
 
-        $(document).on("click", '[ng-click="switchToSideBySideLayout()"], [ng-click="switchToFlatLayout()"]', () => {
-            this.dispatch("layoutChanged");
-        });
+        $(document).on(
+            "click",
+            "[ng-click=\"switchToSideBySideLayout('editor')\"], " +
+                "[ng-click=\"switchToFlatLayout('pdf')\"], " +
+                "[ng-click=\"switchToFlatLayout('editor')\"] ",
+            () => {
+                this.dispatch("layoutChanged");
+            }
+        );
     }
 
     public updateFiles(): Promise<File[]> {

--- a/app/scripts/tabs.ts
+++ b/app/scripts/tabs.ts
@@ -214,8 +214,7 @@ export class TabModule {
         this.shortcut.addEventListener("Meta+9", goToTab);
 
         const goToPreviousTab = (e) => {
-            if(this._previousTab)
-                this.slext.selectFile(this._previousTab.file);
+            if (this._previousTab) this.slext.selectFile(this._previousTab.file);
             e.preventDefault();
         };
 
@@ -383,8 +382,7 @@ export class TabModule {
 
     private selectTab(index: number): void {
         if (this._currentTab) this._currentTab.tab.removeClass("slext-tabs__tab--active");
-        if(this._currentTab != this._tabs[index])
-            this._previousTab = this._currentTab;
+        if (this._currentTab != this._tabs[index]) this._previousTab = this._currentTab;
         this._currentTab = this._tabs[index];
         if (this._currentTab) this._currentTab.tab.addClass("slext-tabs__tab--active");
     }

--- a/app/scripts/tabs.ts
+++ b/app/scripts/tabs.ts
@@ -22,6 +22,7 @@ export class TabModule {
     private static tabTemplate: string = require("../templates/tab.html");
     protected _tabs: Tab[] = [];
     protected _currentTab: Tab;
+    protected _previousTab: Tab;
     protected tabBar: JQuery<HTMLElement>;
     private currentFile: File = null;
     private maintab: Tab = null;
@@ -67,6 +68,8 @@ export class TabModule {
                     this.setMainTab(this._tabs[tab]);
                 }
             });
+
+            this._previousTab = null;
         });
 
         window.onbeforeunload = () => this.saveTabs();
@@ -199,6 +202,7 @@ export class TabModule {
             this.slext.selectFile(this._tabs[tabIndex].file);
             e.preventDefault();
         };
+
         this.shortcut.addEventListener("Meta+1", goToTab);
         this.shortcut.addEventListener("Meta+2", goToTab);
         this.shortcut.addEventListener("Meta+3", goToTab);
@@ -208,6 +212,14 @@ export class TabModule {
         this.shortcut.addEventListener("Meta+7", goToTab);
         this.shortcut.addEventListener("Meta+8", goToTab);
         this.shortcut.addEventListener("Meta+9", goToTab);
+
+        const goToPreviousTab = (e) => {
+            if(this._previousTab)
+                this.slext.selectFile(this._previousTab.file);
+            e.preventDefault();
+        };
+
+        this.shortcut.addEventListener("Meta+0", goToPreviousTab);
 
         $("html").on("click", ".slext-tabs__tab-cross", (e) => {
             e.stopPropagation();
@@ -371,6 +383,8 @@ export class TabModule {
 
     private selectTab(index: number): void {
         if (this._currentTab) this._currentTab.tab.removeClass("slext-tabs__tab--active");
+        if(this._currentTab != this._tabs[index])
+            this._previousTab = this._currentTab;
         this._currentTab = this._tabs[index];
         if (this._currentTab) this._currentTab.tab.addClass("slext-tabs__tab--active");
     }
@@ -449,6 +463,9 @@ export class TabModule {
             const index = this._tabs.indexOf(tab);
             this._tabs.splice(index, 1);
             tab.tab.remove();
+        }
+        if (tab == this._previousTab) {
+            this._previousTab = null;
         }
         if (tab == this.temporarytab) {
             this.temporarytab = null;

--- a/app/scripts/tabs.ts
+++ b/app/scripts/tabs.ts
@@ -218,7 +218,7 @@ export class TabModule {
             e.preventDefault();
         };
 
-        this.shortcut.addEventListener("Meta+0", goToPreviousTab);
+        this.shortcut.addEventListener("Meta+B", goToPreviousTab);
 
         $("html").on("click", ".slext-tabs__tab-cross", (e) => {
             e.stopPropagation();

--- a/app/styles/contentscript.scss
+++ b/app/styles/contentscript.scss
@@ -332,8 +332,7 @@
         height: 64px;
         color: var(--fileColor);
         cursor: pointer;
-        &--selected,
-        &:hover {
+        &--selected {
             color: var(--accentColor);
         }
 

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -132,6 +132,13 @@
                             <code>9</code>
                         </td>
                     </tr>
+                    <tr>
+                        <td class="slext-binding-description">Jump to previous tab</td>
+                        <td class="slext-binding-command">
+                            <code class="sl_meta_key_icon">{{meta_key}}</code>
+                            <code>0</code>
+                        </td>
+                    </tr>
                 </table>
             </div>
             <div class="slext-settings__section">

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -136,7 +136,7 @@
                         <td class="slext-binding-description">Jump to previous tab</td>
                         <td class="slext-binding-command">
                             <code class="sl_meta_key_icon">{{meta_key}}</code>
-                            <code>0</code>
+                            <code>B</code>
                         </td>
                     </tr>
                     <tr>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -139,6 +139,20 @@
                             <code>0</code>
                         </td>
                     </tr>
+                    <tr>
+                        <td class="slext-binding-description">Toggle full-screen editor/PDF</td>
+                        <td class="slext-binding-command">
+                            <code class="sl_meta_key_icon">{{meta_key}}</code>
+                            <code>Y</code>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="slext-binding-description">Switch to split-screen view</td>
+                        <td class="slext-binding-command">
+                            <code class="sl_meta_key_icon">{{meta_key}}</code>
+                            <code>U</code>
+                        </td>
+                    </tr>
                 </table>
             </div>
             <div class="slext-settings__section">


### PR DESCRIPTION
Hi!
This PR includes:

- Shortcut for switching to previously visited tab (currently Meta+0)
- Shortcuts for switching the layout (currently Meta+U for switching to split-screen, Meta+Y for toggling between full-screen PDF and editor)
- Some minor fixes

Thank you!